### PR TITLE
#165335584 Admin/Staff Can Delete Account API Endpoint

### DIFF
--- a/server/api/__test__/acctTest.js
+++ b/server/api/__test__/acctTest.js
@@ -65,3 +65,26 @@ describe('Account Status Tests', () => {
       });
   });
 });
+describe('Delete Account Tests', () => {
+  it('should delete account successfully', (done) => {
+    chai.request(app)
+      .post('/api/v1/auth/signin')
+      .send({
+        email: 'admin@banka.com',
+        password: 'password',
+      })
+      .end((error, response) => {
+        const token = `Bearer ${response.body.data.token}`;
+        chai.request(app)
+          .delete('/api/v1/accounts/4530797010')
+          .set('Authorization', token)
+
+          .end((err, res) => {
+            res.body.should.be.a('object');
+            res.body.should.have.status(200);
+            res.body.should.have.property('message');
+            done();
+          });
+      });
+  });
+});

--- a/server/api/controllers/acctController.js
+++ b/server/api/controllers/acctController.js
@@ -50,5 +50,28 @@ class AccoountController {
       error: `Account ${accountNumber} does not exist`,
     });
   }
+
+  // eslint-disable-next-line consistent-return
+  static deleteAccount(req, res) {
+    const { accountNumber } = req.params;
+    const validAccount = accounts
+      .find(eachAccount => eachAccount.accountNumber === parseInt(accountNumber, 10));
+    if (!validAccount) {
+      return res.status(404).json({
+        status: res.statusCode,
+        error: `Account ${accountNumber} does not exist`,
+      });
+    }
+    accounts.forEach((account) => {
+      if (account.accountNumber === parseInt(accountNumber, 10)) {
+        const indexNumber = accounts.indexOf(account);
+        accounts.splice(indexNumber, 1);
+      }
+      return res.status(200).json({
+        status: res.statusCode,
+        message: 'Account successfully deleted!',
+      });
+    });
+  }
 }
 export default AccoountController;

--- a/server/api/routes/index.js
+++ b/server/api/routes/index.js
@@ -13,5 +13,6 @@ router.post('/auth/signup', UserController.signup);
 router.post('/auth/signin', UserController.signin);
 router.post('/accounts', Verification.user, AcctController.createAccount);
 router.patch('/accounts/:accountNumber', Verification.admin, AcctController.accountStatus);
+router.delete('/accounts/:accountNumber', Verification.admin, AcctController.deleteAccount);
 
 export default router;


### PR DESCRIPTION
#### What does this PR do?
Have delete account test and endpoints working

#### Description of Task to be completed?
-wrote delete account test
-worked on the account route to implement delete account API endpoints

#### How should this be manually tested?
Go to postman and make a DELETE request with admin or staff log in details (admin/staff token)
that is:
 
```
DELETE/api/v1/acccounts/accountNumber
```

#### What are the relevant pivotal tracker stories?
#165335584